### PR TITLE
Add simple Hello World PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Hello World PWA
+
+This repository contains a minimal Progressive Web App that displays "Hello World".
+
+## Running locally
+
+You can serve the files with any static file server. For example using Python:
+
+```bash
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080` in your browser. The service worker will cache the files for offline use.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World PWA</title>
+    <link rel="manifest" href="manifest.json">
+</head>
+<body>
+    <h1>Hello World</h1>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,6 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Hello World PWA",
+    "short_name": "HelloPWA",
+    "start_url": ".",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "description": "A simple Hello World PWA"
+}
+

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,17 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('hello-pwa').then(cache => cache.addAll([
+      '/',
+      '/index.html',
+      '/manifest.json',
+      '/main.js'
+    ]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+


### PR DESCRIPTION
## Summary
- add a minimal PWA example with `index.html`, `manifest.json`, `main.js` and `service-worker.js`
- document how to run the app locally in `README.md`

## Testing
- `npm test` *(fails: Could not read package.json)*